### PR TITLE
Adding --allow-root parameter that is now required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          ffmpeg && \
      rm -rf /var/lib/apt/lists/*
 
-RUN /opt/conda/bin/conda install -y nodejs opencv Cython tensorflow pandas scikit-learn matplotlib seaborn jupyter jupyterlab && \
-    /opt/conda/bin/conda install -c conda-forge tensorboardx && \
+RUN /opt/conda/bin/conda install -y opencv Cython pandas scikit-learn matplotlib seaborn jupyter jupyterlab && \
     /opt/conda/bin/conda clean -ya
 
-RUN jupyter labextension install jupyterlab_tensorboard
-
-RUN pip install jupyter_tensorboard torchvision scikit-image
+RUN pip install torchvision scikit-image scikit-learn-intelex
 
 RUN mkdir -p /home/me && chmod 1777 /home/me
 
 ENV HOME /home/me
 
-# tensorboard
-EXPOSE 6006
 # jupyter notebook
 EXPOSE 8888
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 jupyter tensorboard enable --user
-jupyter lab --no-browser --ip=0.0.0.0 --port=8888
+jupyter lab --allow-root --no-browser --ip=0.0.0.0 --port=8888


### PR DESCRIPTION
Without this option, JupyterLab will exit with the error
Running as root is not recommended. Use --allow-root to bypass.
